### PR TITLE
Fix gfx::Buffer lifecycle in jsb.RenderingSubMesh. RenderingSubMesh should own vertex & index buffers.

### DIFF
--- a/cocos/core/assets/rendering-sub-mesh.jsb.ts
+++ b/cocos/core/assets/rendering-sub-mesh.jsb.ts
@@ -1,5 +1,6 @@
 import { ccclass } from "cc.decorator";
 import {Vec3} from "../math";
+import { Attribute, PrimitiveMode, Buffer } from "../gfx";
 
 /**
  * @en Array views for index buffer
@@ -49,3 +50,54 @@ export interface IFlatBuffer {
 
 export type RenderingSubMesh = jsb.RenderingSubMesh;
 export const RenderingSubMesh = jsb.RenderingSubMesh;
+
+const renderingSubMeshProto = RenderingSubMesh.prototype;
+
+renderingSubMeshProto._ctor = function (vertexBuffers: Buffer[], attributes: Attribute[], primitiveMode: PrimitiveMode,
+                                             indexBuffer: Buffer | null = null, indirectBuffer: Buffer | null = null) {
+    this._attributes = attributes;
+    this._vertexBuffers = vertexBuffers;
+    this._indexBuffer = indexBuffer;
+    this._indirectBuffer = indirectBuffer;
+    this._primitiveMode = primitiveMode;
+};
+
+Object.defineProperty(renderingSubMeshProto, 'attributes', {
+    configurable: true,
+    enumerable: true,
+    get () {
+        return this._attributes;
+    }
+});
+
+Object.defineProperty(renderingSubMeshProto, 'vertexBuffers', {
+    configurable: true,
+    enumerable: true,
+    get () {
+        return this._vertexBuffers;
+    }
+});
+
+Object.defineProperty(renderingSubMeshProto, 'indexBuffer', {
+    configurable: true,
+    enumerable: true,
+    get () {
+        return this._indexBuffer;
+    }
+});
+
+Object.defineProperty(renderingSubMeshProto, 'indirectBuffer', {
+    configurable: true,
+    enumerable: true,
+    get () {
+        return this._indirectBuffer;
+    }
+});
+
+Object.defineProperty(renderingSubMeshProto, 'primitiveMode', {
+    configurable: true,
+    enumerable: true,
+    get () {
+        return this._primitiveMode;
+    }
+});


### PR DESCRIPTION


Re: cocos-creator/3d-tasks#

Changelog:
 * 

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
