### PR TITLE
Fix ImageAsset.width/height getter, keep the same logic as web implementation.

### DIFF
--- a/cocos/core/assets/image-asset.jsb.ts
+++ b/cocos/core/assets/image-asset.jsb.ts
@@ -70,6 +70,8 @@ const imageAssetProto = ImageAsset.prototype;
 
 imageAssetProto._ctor = function (nativeAsset?: ImageSource) {
     jsb.Asset.prototype._ctor.apply(this, arguments);
+    this._width = 0;
+    this._height = 0;
     this._nativeData = {
         _data: null,
         width: 0,

--- a/cocos/core/assets/image-asset.jsb.ts
+++ b/cocos/core/assets/image-asset.jsb.ts
@@ -94,7 +94,7 @@ Object.defineProperty(imageAssetProto, '_nativeAsset', {
     set (value: ImageSource) {
         if (!(value instanceof HTMLElement) && !isImageBitmap(value)) {
             // @ts-expect-error internal API usage
-            value.format = value.format || this._format;
+            value.format = value.format || this.format;
         }
         this.reset(value);
     },

--- a/cocos/core/assets/image-asset.jsb.ts
+++ b/cocos/core/assets/image-asset.jsb.ts
@@ -120,6 +120,8 @@ imageAssetProto._setRawAsset = function (filename: string, inLibrary = true) {
 
 imageAssetProto.reset = function (data: ImageSource) {
     this._nativeData = data;
+    this._width = data.width;
+    this._height = data.height;
 
     if (!(data instanceof HTMLElement)) {
         // @ts-expect-error internal api usage
@@ -128,10 +130,28 @@ imageAssetProto.reset = function (data: ImageSource) {
     this._syncDataToNative();
 };
 
+Object.defineProperty(imageAssetProto, 'width', {
+    configurable: true,
+    enumerable: true,
+    get () {
+        return this._nativeData.width || this._width;
+    }
+});
+
+Object.defineProperty(imageAssetProto, 'height', {
+    configurable: true,
+    enumerable: true,
+    get () {
+        return this._nativeData.height || this._height;
+    }
+});
+
 imageAssetProto._syncDataToNative = function () {
     const data: any = this._nativeData;
-    this.width = data.width;
-    this.height = data.height;
+
+    this.setWidth(this._width);
+    this.setHeight(this._height);
+
     if (data instanceof HTMLCanvasElement) {
         this.setData(data._data.data);
     }
@@ -148,8 +168,8 @@ imageAssetProto._deserialize = function (data: any) {
     if (typeof data === 'string') {
         fmtStr = data;
     } else {
-        this.width = data.w;
-        this.height = data.h;
+        this._width = data.w;
+        this._height = data.h;
         fmtStr = data.fmt;
     }
     const device = legacyCC.director.root.device;

--- a/cocos/core/assets/texture-2d.jsb.ts
+++ b/cocos/core/assets/texture-2d.jsb.ts
@@ -62,6 +62,7 @@ const _descriptor$a = _applyDecoratedDescriptor(_class2$c.prototype, '_mipmaps',
 
 texture2DProto._ctor = function () {
     SimpleTexture.prototype._ctor.apply(this, arguments);
+    this._mipmaps = [];
     // for deserialization
     // _initializerDefineProperty(_this, 'isRGBE', _descriptor$b, _assertThisInitialized(_this));
     // _initializerDefineProperty(_this, '_mipmaps', _descriptor2$7, _assertThisInitialized(_this));
@@ -95,11 +96,10 @@ Object.defineProperty(texture2DProto, 'image', {
     configurable: true,
     enumerable: true,
     get () {
-        return this.getImage();
+        return this._mipmaps.length === 0 ? null : this._mipmaps[0];
     },
-    set (v) {
-        v._syncDataToNative();
-        this.setImage(v);
+    set (value) {
+        this.mipmaps = value ? [value] : [];
     }
 });
 
@@ -107,14 +107,14 @@ Object.defineProperty(texture2DProto, 'mipmaps', {
     configurable: true,
     enumerable: true,
     get () {
-        return this.getMipmaps();
+        return this._mipmaps;
     },
     set (arr) {
         for (let i = 0, len = arr.length; i < len; ++i) {
-            const v = arr[i];
-            v._syncDataToNative();
-            this.setMipmaps(v);
+            arr[i]._syncDataToNative();
         }
+        this._mipmaps = arr;
+        this.setMipmaps(arr);
     }
 });
 


### PR DESCRIPTION
And optimize Texture2D.mipmaps/image getter and setter.

<img width="960" alt="wecom-temp-c9385ba39615e8b2e0a6fa1c4b96b91e" src="https://user-images.githubusercontent.com/493372/144001287-78ea82a0-2cde-4f6a-ba1c-2093fb0b847e.png">


Re: cocos-creator/3d-tasks#

Changelog:
 * 

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
