### PR TITLE
Share memory of Node::_layer to reduce JSB calls, lazy update _scene property. Lazy getting _renderScene property.

### DIFF
--- a/cocos/core/scene-graph/node.jsb.ts
+++ b/cocos/core/scene-graph/node.jsb.ts
@@ -837,6 +837,29 @@ Object.defineProperty(nodeProto, '_activeInHierarchy', {
     },
 });
 
+Object.defineProperty(nodeProto, 'layer', {
+    configurable: true,
+    enumerable: true,
+    get () {
+        return this._layerArr[0];
+    },
+    set (v) {
+        this._layerArr[0] = v;
+        this.emit(NodeEventType.LAYER_CHANGED, v);
+    },
+});
+
+Object.defineProperty(nodeProto, '_layer', {
+    configurable: true,
+    enumerable: true,
+    get () {
+        return this._layerArr[0];
+    },
+    set (v) {
+        this._layerArr[0] = v;
+    },
+});
+
 Object.defineProperty(nodeProto, 'forward', {
     configurable: true,
     enumerable: true,
@@ -913,6 +936,14 @@ Object.defineProperty(nodeProto, 'children', {
     set (v) {
         this._children = v;
     },
+});
+
+Object.defineProperty(nodeProto, 'scene', {
+    configurable: true,
+    enumerable: true,
+    get () {
+        return this._scene;
+    }
 });
 
 nodeProto.rotate = function (rot: Quat, ns?: NodeSpace): void {
@@ -1006,6 +1037,10 @@ nodeProto._onBatchCreated = function (dontSyncChildPrefab: boolean) {
 
     // Sync node _lpos, _lrot, _lscale to native
     syncNodeValues(this);
+};
+
+nodeProto._onSceneUpdated = function (scene) {
+    this._scene = scene;
 };
 
 nodeProto._instantiate = function (cloned: Node, isSyncedNode: boolean) {
@@ -1163,6 +1198,8 @@ nodeProto._ctor = function (name?: string) {
     this._eventProcessor = new legacyCC.NodeEventProcessor(this);
     this._uiProps = new NodeUIProperties(this);
     this._activeInHierarchyArr = new Uint8Array([0]);
+    this._layerArr = new Uint32Array([Layers.Enum.DEFAULT]);
+    this._scene = null;
     this._prefab = null;
 
     this._registerListeners();

--- a/cocos/core/scene-graph/scene.jsb.ts
+++ b/cocos/core/scene-graph/scene.jsb.ts
@@ -61,6 +61,28 @@ Object.defineProperty(sceneProto, 'globals', {
     },
 });
 
+Object.defineProperty(sceneProto, '_renderScene', {
+    enumerable: true,
+    configurable: true,
+    get () {
+        if (!this._renderSceneInternal) {
+            this._renderSceneInternal = this.getRenderScene();
+        }
+        return this._renderSceneInternal;
+    }
+});
+
+Object.defineProperty(sceneProto, 'renderScene', {
+    enumerable: true,
+    configurable: true,
+    get () {
+        if (!this._renderSceneInternal) {
+            this._renderSceneInternal = this.getRenderScene();
+        }
+        return this._renderSceneInternal;
+    }
+});
+
 _applyDecoratedDescriptor(_class2$x.prototype, 'globals', [editable], Object.getOwnPropertyDescriptor(_class2$x.prototype, 'globals'), _class2$x.prototype);
 const _descriptor$r = _applyDecoratedDescriptor(_class2$x.prototype, 'autoReleaseAssets', [serializable, editable], {
     configurable: true,
@@ -83,6 +105,7 @@ const _descriptor2$k = _applyDecoratedDescriptor(_class2$x.prototype, '_globals'
 sceneProto._ctor = function () {
     Node.prototype._ctor.apply(this, arguments);
     this._inited = false;
+    this._renderSceneInternal = null;
     this._globalRef = null;
     this._prefabSyncedInLiveReload = false;
     // eslint-disable-next-line @typescript-eslint/no-this-alias
@@ -109,6 +132,7 @@ sceneProto._onBatchCreated = function(dontSyncChildPrefab: boolean) {
 
 const oldLoad = sceneProto._load;
 sceneProto._load = function () {
+    this._scene = this;
     if (!this._inited) {
         if (TEST) {
             assert(!this._activeInHierarchy, 'Should deactivate ActionManager and EventManager by default');


### PR DESCRIPTION
https://github.com/minggo/engine-native/pull/307

Re: cocos-creator/3d-tasks#

Changelog:
 * 

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
